### PR TITLE
Add optional pollInterval to portname polling function

### DIFF
--- a/SerialPortRx/SerialPortRx.cs
+++ b/SerialPortRx/SerialPortRx.cs
@@ -121,9 +121,9 @@
         /// Gets the port names.
         /// </summary>
         /// <value>The port names.</value>
-        public static IObservable<string[]> PortNames => Observable.Create<string[]>(obs => {
+        public static IObservable<string[]> PortNames (int timeOut = 500) => Observable.Create<string[]>(obs => {
             string[] compare = null;
-            return Observable.Interval(TimeSpan.FromMilliseconds(500)).Subscribe(_ => {
+            return Observable.Interval(TimeSpan.FromMilliseconds(timeOut)).Subscribe(_ => {
                 var compareNew = SerialPort.GetPortNames();
                 if (compareNew.Length == 0) {
                     compareNew = new string[] { "NoPorts" };

--- a/SerialPortRx/SerialPortRx.cs
+++ b/SerialPortRx/SerialPortRx.cs
@@ -121,9 +121,9 @@
         /// Gets the port names.
         /// </summary>
         /// <value>The port names.</value>
-        public static IObservable<string[]> PortNames (int timeOut = 500) => Observable.Create<string[]>(obs => {
+        public static IObservable<string[]> PortNames (int pollInterval = 500) => Observable.Create<string[]>(obs => {
             string[] compare = null;
-            return Observable.Interval(TimeSpan.FromMilliseconds(timeOut)).Subscribe(_ => {
+            return Observable.Interval(TimeSpan.FromMilliseconds(pollInterval)).Subscribe(_ => {
                 var compareNew = SerialPort.GetPortNames();
                 if (compareNew.Length == 0) {
                     compareNew = new string[] { "NoPorts" };


### PR DESCRIPTION
Add optional pollInterval to portname polling function

Maybe 500 ms is too often and uses too much CPU.

Maybe there is a reason that an application miight want to poll for new port names at a reduced interval rate. 