### PR TITLE
Add line-based reading and streaming to SerialPortRx

### DIFF
--- a/src/SerialPortRx.Tests/SerialPortRx.Lines.Tests.cs
+++ b/src/SerialPortRx.Tests/SerialPortRx.Lines.Tests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CP.IO.Ports.Tests;
+
+public class SerialPortRx_Lines_Tests
+{
+    [Fact]
+    public async Task Lines_Emits_Complete_Lines_SingleChar_Newline()
+    {
+        var sut = new SerialPortRx.SerialPortRx("COM1");
+        var dataReceivedField = typeof(SerialPortRx.SerialPortRx).GetField("_dataReceived", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var subject = (System.Reactive.Subjects.Subject<char>)dataReceivedField!.GetValue(sut)!;
+        var backingField = typeof(SerialPortRx.SerialPortRx).GetField("<IsOpen>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        backingField!.SetValue(sut, true);
+        sut.NewLine = "\n";
+
+        string? line1 = null;
+        string? line2 = null;
+        using var sub = sut.Lines.Subscribe(l =>
+        {
+            if (line1 == null) line1 = l; else line2 = l;
+        });
+
+        subject.OnNext('a');
+        subject.OnNext('\n');
+        subject.OnNext('b');
+        subject.OnNext('\n');
+
+        await Task.Delay(10);
+
+        Assert.Equal("a", line1);
+        Assert.Equal("b", line2);
+    }
+
+    [Fact]
+    public async Task Lines_Emits_Complete_Lines_MultiChar_Newline()
+    {
+        var sut = new SerialPortRx.SerialPortRx("COM1");
+        var dataReceivedField = typeof(SerialPortRx.SerialPortRx).GetField("_dataReceived", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var subject = (System.Reactive.Subjects.Subject<char>)dataReceivedField!.GetValue(sut)!;
+        var backingField = typeof(SerialPortRx.SerialPortRx).GetField("<IsOpen>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        backingField!.SetValue(sut, true);
+        sut.NewLine = "\r\n";
+
+        string? line = null;
+        using var sub = sut.Lines.Subscribe(l => line = l);
+
+        subject.OnNext('x');
+        subject.OnNext('\r');
+        subject.OnNext('\n');
+
+        await Task.Delay(10);
+        Assert.Equal("x", line);
+    }
+}

--- a/src/SerialPortRx.Tests/SerialPortRx.ReadLineAsync.Tests.cs
+++ b/src/SerialPortRx.Tests/SerialPortRx.ReadLineAsync.Tests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CP.IO.Ports.Tests;
+
+public class SerialPortRx_ReadLineAsync_Tests
+{
+    [Fact]
+    public async Task ReadLineAsync_Completes_On_Single_Char_NewLine()
+    {
+        var sut = new SerialPortRx.SerialPortRx("COM1");
+
+        // Arrange: make port appear open and push data into the DataReceived subject via reflection
+        var isOpenField = typeof(SerialPortRx.SerialPortRx).GetProperty("IsOpen");
+        Assert.NotNull(isOpenField);
+
+        // We cannot truly open hardware here; instead, simulate by invoking the internal _dataReceived
+        var dataReceivedField = typeof(SerialPortRx.SerialPortRx).GetField("_dataReceived", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(dataReceivedField);
+        var subject = (System.Reactive.Subjects.Subject<char>)dataReceivedField!.GetValue(sut)!;
+
+        // Pretend it's open
+        var isOpenProp = typeof(SerialPortRx.SerialPortRx).GetProperty("IsOpen");
+        var backingField = typeof(SerialPortRx.SerialPortRx).GetField("<IsOpen>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(backingField);
+        backingField!.SetValue(sut, true);
+
+        sut.NewLine = "\n";
+
+        var task = sut.ReadLineAsync();
+
+        subject.OnNext('H');
+        subject.OnNext('i');
+        subject.OnNext('\n');
+
+        var result = await task.ConfigureAwait(false);
+        Assert.Equal("Hi", result);
+    }
+
+    [Fact]
+    public async Task ReadLineAsync_Completes_On_Multi_Char_NewLine()
+    {
+        var sut = new SerialPortRx.SerialPortRx("COM1");
+        var dataReceivedField = typeof(SerialPortRx.SerialPortRx).GetField("_dataReceived", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var subject = (System.Reactive.Subjects.Subject<char>)dataReceivedField!.GetValue(sut)!;
+        var backingField = typeof(SerialPortRx.SerialPortRx).GetField("<IsOpen>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        backingField!.SetValue(sut, true);
+
+        sut.NewLine = "\r\n";
+
+        var task = sut.ReadLineAsync();
+
+        subject.OnNext('O');
+        subject.OnNext('K');
+        subject.OnNext('\r');
+        subject.OnNext('\n');
+
+        var result = await task.ConfigureAwait(false);
+        Assert.Equal("OK", result);
+    }
+
+    [Fact]
+    public async Task ReadLineAsync_Times_Out_When_No_NewLine()
+    {
+        var sut = new SerialPortRx.SerialPortRx("COM1") { ReadTimeout = 50 };
+        var dataReceivedField = typeof(SerialPortRx.SerialPortRx).GetField("_dataReceived", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var subject = (System.Reactive.Subjects.Subject<char>)dataReceivedField!.GetValue(sut)!;
+        var backingField = typeof(SerialPortRx.SerialPortRx).GetField("<IsOpen>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        backingField!.SetValue(sut, true);
+
+        sut.NewLine = "\n";
+
+        var task = sut.ReadLineAsync();
+
+        subject.OnNext('A');
+        // No newline provided -> expect timeout
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(async () => await task.ConfigureAwait(false));
+        Assert.Equal("ReadLineAsync timed out.", ex.Message);
+    }
+}

--- a/src/SerialPortRx.Tests/SerialPortRx.Tests.csproj
+++ b/src/SerialPortRx.Tests/SerialPortRx.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>CP.IO.Ports.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SerialPortRx\SerialPortRx.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SerialPortRx/ISerialPortRx.cs
+++ b/src/SerialPortRx/ISerialPortRx.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO.Ports;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CP.IO.Ports;
 
@@ -123,4 +125,17 @@ public interface ISerialPortRx : IPortRx
     /// </summary>
     /// <param name="text">The text.</param>
     void WriteLine(string text);
+
+    /// <summary>
+    /// Reads the line asynchronous.
+    /// </summary>
+    /// <returns>A Task of string.</returns>
+    Task<string> ReadLineAsync();
+
+    /// <summary>
+    /// Reads the line asynchronous with cancellation and respecting ReadTimeout (> 0) as a timeout.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token to cancel waiting.</param>
+    /// <returns>A Task of string.</returns>
+    Task<string> ReadLineAsync(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
Introduces ReadLineAsync methods and a Lines observable to SerialPortRx for reading complete lines split by configurable NewLine sequences. Updates ISerialPortRx interface, implements line parsing logic, and adds unit tests for both single- and multi-character newlines and timeout handling. Documentation is updated to describe new features and usage.