### PR TITLE
Add serial source generator and tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <NoWarn>$(NoWarn);CS1591;IDE0190;IDE1006;SA1010</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageReleaseNotes>Compatability with Net 8/ 9/ 10 and netstandard2.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Compatibility with .NET 8/9/10, TUnit/MTP tests, async observable bridges, and serial reactive stream source generation.</PackageReleaseNotes>
     <PackageTags>SerialPort;rx;reactive;extensions;observable;LINQ;net;netstandard</PackageTags>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ A Reactive Serial, TCP, and UDP I/O library that exposes incoming data as IObser
   - IsOpenObservable: IObservable<bool> for connection state
   - ErrorReceived: IObservable<Exception> for errors
   - PinChanged: IObservable<SerialPinChangedEventArgs> for pin state changes (Windows only)
+- Async observables:
+  - Concrete serial, TCP, and UDP types expose IObservableAsync<T> counterparts.
+  - IPortRx and ISerialPortRx extension methods bridge existing streams to IObservableAsync<T>.
+  - SerialPortRx helpers include async BufferUntil, WhileIsOpenAsync, and PortNamesAsync variants.
 - Synchronous read methods for manual data consumption
 - TCP/UDP batched reads:
   - TcpClientRx.DataReceivedBatches: IObservable<byte[]> chunks per read loop
   - UdpClientRx.DataReceivedBatches: IObservable<byte[]> per received datagram
+- Source generator support:
+  - SerialPortReactiveStream attributes generate properties, IObservable<T>, IObservableAsync<T>, and a connection method for serial protocol values.
 - Helpers:
   - PortNames(): reactive port enumeration with change notifications
   - BufferUntil(): message framing between start and end delimiters with timeout
@@ -28,6 +34,8 @@ A Reactive Serial, TCP, and UDP I/O library that exposes incoming data as IObser
 
 ## Installation
 - dotnet add package SerialPortRx
+
+The package includes the SerialPortRx source generator as an analyzer. No separate generator package is required.
 
 ## Supported target frameworks
 - netstandard2.0
@@ -93,6 +101,54 @@ SerialPortRx.PortNames()
     })
     .ForEach()
     .Subscribe();
+```
+
+## Async observables
+SerialPortRx uses ReactiveUI.Extensions async observables for consumers that need asynchronous observer callbacks and full `IObservableAsync<T>` operators.
+
+```csharp
+using CP.IO.Ports;
+using ReactiveUI.Extensions.Async;
+
+var port = new SerialPortRx("COM3", 115200);
+
+await using var lines = await port.LinesAsync.SubscribeAsync(
+    async (line, cancellationToken) =>
+    {
+        await ProcessLineAsync(line, cancellationToken);
+    });
+
+await port.Open();
+```
+
+Concrete types expose async properties:
+- `SerialPortRx.DataReceivedAsync`, `DataReceivedBytesAsync`, `LinesAsync`, `BytesReceivedAsync`, `IsOpenObservableAsync`, `ErrorReceivedAsync`
+- `TcpClientRx.DataReceivedAsync`, `DataReceivedBatchesAsync`, `BytesReceivedAsync`
+- `UdpClientRx.DataReceivedAsync`, `DataReceivedBatchesAsync`, `BytesReceivedAsync`
+
+Interface consumers can use extension methods without requiring a new interface contract:
+```csharp
+ISerialPortRx serial = port;
+await using var state = await serial.IsOpenObservableAsync()
+    .WhereTrue()
+    .SubscribeAsync(_ => Console.WriteLine("Open"));
+
+IPortRx common = port;
+await using var bytes = await common.BytesReceivedAsync()
+    .SubscribeAsync(value => Console.WriteLine(value));
+```
+
+Async helper variants are also available:
+```csharp
+var start = 0x21.AsObservableAsync();
+var end = 0x0a.AsObservableAsync();
+
+await using var framed = await port.DataReceivedAsync
+    .BufferUntil(start, end, timeOut: 100)
+    .SubscribeAsync(message => Console.WriteLine(message));
+
+await using var names = await SerialPortRxMixins.PortNamesAsync()
+    .SubscribeAsync(ports => Console.WriteLine(string.Join(", ", ports)));
 ```
 
 ## Message framing with BufferUntil
@@ -232,6 +288,40 @@ port.NewLine = "\n";
 port.Lines.Subscribe(line => Console.WriteLine($"LINE: {line}"));
 ```
 
+## Source-generated serial properties
+The package includes a source generator that can turn serial protocol messages into strongly typed properties with classic and async observable streams. Mark a partial class with one or more `SerialPortReactiveStream` attributes, then connect it to an `ISerialPortRx`.
+
+```csharp
+using CP.IO.Ports;
+using CP.IO.Ports.SourceGeneration;
+using ReactiveUI.Extensions.Async;
+
+[SerialPortReactiveStream("Temperature", typeof(double), @"^TEMP:(?<value>-?\d+(\.\d+)?)$")]
+[SerialPortReactiveStream("DeviceReady", typeof(bool), @"^READY:(?<value>0|1)$", IgnoreCase = true)]
+public partial class DeviceState
+{
+}
+
+var port = new SerialPortRx("COM3", 115200);
+var state = new DeviceState();
+using var generatedBindings = state.ConnectReactiveSerialPort(port);
+
+state.TemperatureObservable.Subscribe(value => Console.WriteLine($"Temperature: {value}"));
+
+await using var ready = await state.DeviceReadyObservableAsync
+    .SubscribeAsync(value => Console.WriteLine($"Ready: {value}"));
+
+await port.Open();
+```
+
+Generated members:
+- `Temperature` and `DeviceReady` properties with private setters
+- `TemperatureObservable` / `DeviceReadyObservable`
+- `TemperatureObservableAsync` / `DeviceReadyObservableAsync`
+- `ConnectReactiveSerialPort(ISerialPortRx serialPort)` to wire the generated bindings
+
+By default, generated bindings listen to `ISerialPortRx.Lines`. Set `Source` to `SerialPortReactiveSource.DataReceived`, `DataReceivedBytes`, `BytesReceived`, or `IsOpen` when a property should be driven by a different stream.
+
 ## Writing
 - `port.Write(string text)` - Write a string
 - `port.WriteLine(string text)` - Write a string followed by NewLine
@@ -317,6 +407,15 @@ new TcpClientRx("example.com", 80).DataReceivedBatches
 new UdpClientRx(12345).DataReceivedBatches
     .Subscribe(datagram => Console.WriteLine($"UDP datagram size: {datagram.Length}"));
 ```
+
+## Testing
+The test suite uses TUnit on Microsoft.Testing.Platform. Run it with:
+
+```bash
+dotnet test --project src/SerialPortRx.Test/SerialPortRx.Test.csproj -c Debug -f net8.0
+```
+
+Serial integration tests expect a virtual COM port pair named `COM1` and `COM2`. The source-generator tests do not require serial hardware.
 
 ## Threading and scheduling
 - The DataReceived and other streams run on the underlying event threads. Use ObserveOn to marshal to a UI or a dedicated scheduler when needed.

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    },
     "msbuild-sdks": {
         "MSBuild.Sdk.Extras": "3.0.44"
     }

--- a/src/SerialPortRx.SourceGenerators/SerialPortReactiveStreamGenerator.cs
+++ b/src/SerialPortRx.SourceGenerators/SerialPortReactiveStreamGenerator.cs
@@ -1,0 +1,452 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CP.IO.Ports.SourceGenerators;
+
+/// <summary>
+/// Generates reactive serial-port properties and observable streams.
+/// </summary>
+[Generator(LanguageNames.CSharp)]
+public sealed class SerialPortReactiveStreamGenerator : IIncrementalGenerator
+{
+    private const string AttributeMetadataName = "CP.IO.Ports.SourceGeneration.SerialPortReactiveStreamAttribute";
+    private static readonly DiagnosticDescriptor ClassMustBePartial = new(
+        "SPRX001",
+        "Reactive serial stream target must be partial",
+        "Type '{0}' must be partial to receive generated serial stream members",
+        "SerialPortRx.SourceGeneration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor PropertyNameMustBeIdentifier = new(
+        "SPRX002",
+        "Reactive serial stream property name must be a valid identifier",
+        "Property name '{0}' must be a valid C# identifier",
+        "SerialPortRx.SourceGeneration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        context.RegisterPostInitializationOutput(static postInitializationContext =>
+            postInitializationContext.AddSource("SerialPortReactiveStreamAttribute.g.cs", AttributeSource));
+
+        var streamDeclarations = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                AttributeMetadataName,
+                static (node, _) => node is ClassDeclarationSyntax,
+                static (syntaxContext, cancellationToken) => GetStreamInfos(syntaxContext, cancellationToken));
+
+        context.RegisterSourceOutput(
+            streamDeclarations.Collect(),
+            static (sourceProductionContext, streams) => Execute(sourceProductionContext, streams));
+    }
+
+    private static ImmutableArray<StreamInfo> GetStreamInfos(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (context.TargetSymbol is not INamedTypeSymbol targetType)
+        {
+            return ImmutableArray<StreamInfo>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<StreamInfo>();
+        foreach (var attribute in context.Attributes.Where(attributeData =>
+                     attributeData.AttributeClass?.ToDisplayString() == AttributeMetadataName))
+        {
+            if (TryCreateStreamInfo(targetType, attribute, cancellationToken, out var streamInfo))
+            {
+                builder.Add(streamInfo);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool TryCreateStreamInfo(INamedTypeSymbol targetType, AttributeData attribute, CancellationToken cancellationToken, out StreamInfo streamInfo)
+    {
+        streamInfo = default!;
+        if (attribute.ConstructorArguments.Length < 2)
+        {
+            return false;
+        }
+
+        var propertyName = attribute.ConstructorArguments[0].Value as string ?? string.Empty;
+        var propertyType = attribute.ConstructorArguments[1].Value as ITypeSymbol;
+        var pattern = attribute.ConstructorArguments.Length > 2
+            ? attribute.ConstructorArguments[2].Value as string
+            : null;
+
+        var source = SerialPortReactiveSource.Lines;
+        var groupName = "value";
+        var groupNumber = 1;
+        var ignoreCase = false;
+
+        foreach (var argument in attribute.NamedArguments)
+        {
+            switch (argument.Key)
+            {
+                case "Source":
+                    source = (SerialPortReactiveSource)(argument.Value.Value as int? ?? 0);
+                    break;
+                case "GroupName":
+                    groupName = argument.Value.Value as string;
+                    break;
+                case "GroupNumber":
+                    groupNumber = argument.Value.Value as int? ?? 1;
+                    break;
+                case "IgnoreCase":
+                    ignoreCase = argument.Value.Value as bool? ?? false;
+                    break;
+            }
+        }
+
+        streamInfo = new StreamInfo(
+            targetType,
+            propertyName,
+            propertyType,
+            pattern,
+            source,
+            groupName,
+            groupNumber,
+            ignoreCase,
+            attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken).GetLocation() ?? targetType.Locations.FirstOrDefault());
+
+        return true;
+    }
+
+    private static void Execute(SourceProductionContext context, ImmutableArray<ImmutableArray<StreamInfo>> streamInfoGroups)
+    {
+        var streamInfos = streamInfoGroups.SelectMany(static group => group);
+        foreach (var typeGroup in streamInfos.GroupBy(static info => info.TargetType, SymbolEqualityComparer.Default))
+        {
+            var targetType = typeGroup.First().TargetType;
+            if (!IsPartial(targetType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(ClassMustBePartial, targetType.Locations.FirstOrDefault(), targetType.Name));
+                continue;
+            }
+
+            var streams = new List<StreamInfo>();
+            foreach (var stream in typeGroup)
+            {
+                if (stream.PropertyType == null)
+                {
+                    continue;
+                }
+
+                if (!SyntaxFacts.IsValidIdentifier(stream.PropertyName))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(PropertyNameMustBeIdentifier, stream.Location, stream.PropertyName));
+                    continue;
+                }
+
+                streams.Add(stream);
+            }
+
+            if (streams.Count == 0)
+            {
+                continue;
+            }
+
+            var source = GenerateType(targetType, streams);
+            context.AddSource($"{SanitizeHintName(targetType.ToDisplayString())}.SerialPortReactiveStreams.g.cs", source);
+        }
+    }
+
+    private static bool IsPartial(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.DeclaringSyntaxReferences
+            .Select(reference => reference.GetSyntax())
+            .OfType<ClassDeclarationSyntax>()
+            .Any(classDeclaration => classDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword));
+
+    private static string GenerateType(INamedTypeSymbol targetType, IReadOnlyList<StreamInfo> streams)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("// <auto-generated />");
+        builder.AppendLine("#nullable enable");
+        builder.AppendLine();
+
+        var namespaceName = targetType.ContainingNamespace.IsGlobalNamespace ? null : targetType.ContainingNamespace.ToDisplayString();
+        if (namespaceName != null)
+        {
+            builder.Append("namespace ").Append(namespaceName).AppendLine(";");
+            builder.AppendLine();
+        }
+
+        builder.Append("partial class ").Append(targetType.Name).AppendLine();
+        builder.AppendLine("{");
+
+        foreach (var stream in streams)
+        {
+            AppendStreamMembers(builder, stream);
+        }
+
+        builder.AppendLine("    public global::System.IDisposable ConnectReactiveSerialPort(global::CP.IO.Ports.ISerialPortRx serialPort)");
+        builder.AppendLine("    {");
+        builder.AppendLine("        if (serialPort == null)");
+        builder.AppendLine("        {");
+        builder.AppendLine("            throw new global::System.ArgumentNullException(nameof(serialPort));");
+        builder.AppendLine("        }");
+        builder.AppendLine();
+        builder.AppendLine("        var disposables = new global::System.Reactive.Disposables.CompositeDisposable();");
+
+        foreach (var stream in streams)
+        {
+            AppendSubscription(builder, stream);
+        }
+
+        builder.AppendLine("        return disposables;");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+
+        return builder.ToString();
+    }
+
+    private static void AppendStreamMembers(StringBuilder builder, StreamInfo stream)
+    {
+        var typeName = stream.PropertyType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var fieldName = GetSubjectFieldName(stream.PropertyName);
+
+        builder.Append("    private readonly global::System.Reactive.Subjects.Subject<")
+            .Append(typeName)
+            .Append("> ")
+            .Append(fieldName)
+            .AppendLine(" = new();");
+        builder.AppendLine();
+        builder.Append("    public ").Append(typeName).Append(' ').Append(stream.PropertyName).AppendLine(" { get; private set; } = default!;");
+        builder.AppendLine();
+        builder.Append("    public global::System.IObservable<")
+            .Append(typeName)
+            .Append("> ")
+            .Append(stream.PropertyName)
+            .AppendLine("Observable => global::System.Reactive.Linq.Observable.AsObservable(" + fieldName + ");");
+        builder.AppendLine();
+        builder.Append("    public global::ReactiveUI.Extensions.Async.IObservableAsync<")
+            .Append(typeName)
+            .Append("> ")
+            .Append(stream.PropertyName)
+            .AppendLine("ObservableAsync => global::ReactiveUI.Extensions.Async.ObservableBridgeExtensions.ToObservableAsync(" + stream.PropertyName + "Observable);");
+        builder.AppendLine();
+    }
+
+    private static void AppendSubscription(StringBuilder builder, StreamInfo stream)
+    {
+        var sourceExpression = stream.Source switch
+        {
+            SerialPortReactiveSource.DataReceived => "serialPort.DataReceived",
+            SerialPortReactiveSource.DataReceivedBytes => "serialPort.DataReceivedBytes",
+            SerialPortReactiveSource.BytesReceived => "serialPort.BytesReceived",
+            SerialPortReactiveSource.IsOpen => "serialPort.IsOpenObservable",
+            _ => "serialPort.Lines",
+        };
+
+        var typeName = stream.PropertyType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var fieldName = GetSubjectFieldName(stream.PropertyName);
+
+        builder.Append("        disposables.Add(global::System.ObservableExtensions.Subscribe(")
+            .Append(sourceExpression)
+            .AppendLine(", __serialPortRxValue =>");
+        builder.AppendLine("        {");
+        builder.Append("            if (global::CP.IO.Ports.SourceGeneration.SerialPortReactiveValueConverter.TryConvertMatch<")
+            .Append(typeName)
+            .Append(">(__serialPortRxValue, ")
+            .Append(ToLiteral(stream.Pattern))
+            .Append(", ")
+            .Append(ToLiteral(stream.GroupName))
+            .Append(", ")
+            .Append(stream.GroupNumber.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .Append(", ")
+            .Append(stream.IgnoreCase ? "true" : "false")
+            .AppendLine(", out var __serialPortRxConverted))");
+        builder.AppendLine("            {");
+        builder.Append("                ").Append(stream.PropertyName).AppendLine(" = __serialPortRxConverted;");
+        builder.Append("                ").Append(fieldName).AppendLine(".OnNext(__serialPortRxConverted);");
+        builder.AppendLine("            }");
+        builder.AppendLine("        }));");
+    }
+
+    private static string GetSubjectFieldName(string propertyName) =>
+        "__serialPortRx" + propertyName + "Subject";
+
+    private static string ToLiteral(string? value) =>
+        value == null ? "null" : SymbolDisplay.FormatLiteral(value, quote: true);
+
+    private static string SanitizeHintName(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var character in value)
+        {
+            builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+        }
+
+        return builder.ToString();
+    }
+
+    private enum SerialPortReactiveSource
+    {
+        Lines = 0,
+        DataReceived = 1,
+        DataReceivedBytes = 2,
+        BytesReceived = 3,
+        IsOpen = 4,
+    }
+
+    private sealed class StreamInfo
+    {
+        public StreamInfo(
+            INamedTypeSymbol targetType,
+            string propertyName,
+            ITypeSymbol? propertyType,
+            string? pattern,
+            SerialPortReactiveSource source,
+            string? groupName,
+            int groupNumber,
+            bool ignoreCase,
+            Location? location)
+        {
+            TargetType = targetType;
+            PropertyName = propertyName;
+            PropertyType = propertyType;
+            Pattern = pattern;
+            Source = source;
+            GroupName = groupName;
+            GroupNumber = groupNumber;
+            IgnoreCase = ignoreCase;
+            Location = location;
+        }
+
+        public INamedTypeSymbol TargetType { get; }
+
+        public string PropertyName { get; }
+
+        public ITypeSymbol? PropertyType { get; }
+
+        public string? Pattern { get; }
+
+        public SerialPortReactiveSource Source { get; }
+
+        public string? GroupName { get; }
+
+        public int GroupNumber { get; }
+
+        public bool IgnoreCase { get; }
+
+        public Location? Location { get; }
+    }
+
+    private const string AttributeSource = """
+// <auto-generated />
+#nullable enable
+
+namespace CP.IO.Ports.SourceGeneration;
+
+/// <summary>
+/// Selects the serial stream that drives a generated reactive property.
+/// </summary>
+public enum SerialPortReactiveSource
+{
+    /// <summary>
+    /// The complete line stream from ISerialPortRx.Lines.
+    /// </summary>
+    Lines = 0,
+
+    /// <summary>
+    /// The character stream from ISerialPortRx.DataReceived.
+    /// </summary>
+    DataReceived = 1,
+
+    /// <summary>
+    /// The raw byte stream from ISerialPortRx.DataReceivedBytes.
+    /// </summary>
+    DataReceivedBytes = 2,
+
+    /// <summary>
+    /// The byte stream emitted by ReadAsync via IPortRx.BytesReceived.
+    /// </summary>
+    BytesReceived = 3,
+
+    /// <summary>
+    /// The open state stream from ISerialPortRx.IsOpenObservable.
+    /// </summary>
+    IsOpen = 4,
+}
+
+/// <summary>
+/// Generates a property plus classic and async observable streams from serial data.
+/// </summary>
+[global::System.AttributeUsage(global::System.AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class SerialPortReactiveStreamAttribute : global::System.Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerialPortReactiveStreamAttribute"/> class.
+    /// </summary>
+    /// <param name="propertyName">The generated property name.</param>
+    /// <param name="propertyType">The generated property type.</param>
+    public SerialPortReactiveStreamAttribute(string propertyName, global::System.Type propertyType)
+        : this(propertyName, propertyType, pattern: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerialPortReactiveStreamAttribute"/> class.
+    /// </summary>
+    /// <param name="propertyName">The generated property name.</param>
+    /// <param name="propertyType">The generated property type.</param>
+    /// <param name="pattern">The optional regular expression used to identify relevant data.</param>
+    public SerialPortReactiveStreamAttribute(string propertyName, global::System.Type propertyType, string? pattern)
+    {
+        PropertyName = propertyName;
+        PropertyType = propertyType;
+        Pattern = pattern;
+    }
+
+    /// <summary>
+    /// Gets the generated property name.
+    /// </summary>
+    public string PropertyName { get; }
+
+    /// <summary>
+    /// Gets the generated property type.
+    /// </summary>
+    public global::System.Type PropertyType { get; }
+
+    /// <summary>
+    /// Gets the optional regular expression used to identify relevant data.
+    /// </summary>
+    public string? Pattern { get; }
+
+    /// <summary>
+    /// Gets or sets the serial stream source.
+    /// </summary>
+    public SerialPortReactiveSource Source { get; set; } = SerialPortReactiveSource.Lines;
+
+    /// <summary>
+    /// Gets or sets the named regular expression group converted into the property value.
+    /// </summary>
+    public string? GroupName { get; set; } = "value";
+
+    /// <summary>
+    /// Gets or sets the fallback regular expression group number converted into the property value.
+    /// </summary>
+    public int GroupNumber { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether pattern matching ignores case.
+    /// </summary>
+    public bool IgnoreCase { get; set; }
+}
+""";
+}

--- a/src/SerialPortRx.SourceGenerators/SerialPortRx.SourceGenerators.csproj
+++ b/src/SerialPortRx.SourceGenerators/SerialPortRx.SourceGenerators.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>CP.IO.Ports.SourceGenerators</RootNamespace>
+    <AssemblyName>SerialPortRx.SourceGenerators</AssemblyName>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);RS1036;RS2008;SA1201;SA1203;RCS1197;RCS1201</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/SerialPortRx.Test/SerialPortReactiveStreamGeneratorTests.cs
+++ b/src/SerialPortRx.Test/SerialPortReactiveStreamGeneratorTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CP.IO.Ports.SourceGeneration;
+using CP.IO.Ports.SourceGenerators;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using TUnit.Assertions;
+using TUnit.Core;
+
+namespace CP.IO.Ports.Tests;
+
+/// <summary>
+/// Tests for the serial reactive stream source generator.
+/// </summary>
+public class SerialPortReactiveStreamGeneratorTests
+{
+    /// <summary>
+    /// Verifies generated serial stream properties and observables compile.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task Generator_CreatesPropertyAndObservableStreams()
+    {
+        const string source = """
+using CP.IO.Ports.SourceGeneration;
+
+namespace GeneratedTests;
+
+[SerialPortReactiveStream("Temperature", typeof(double), @"^TEMP:(?<value>-?\d+(\.\d+)?)$")]
+[SerialPortReactiveStream("IsConnected", typeof(bool), Source = SerialPortReactiveSource.IsOpen)]
+public partial class DeviceState
+{
+}
+""";
+
+        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+        var compilation = CreateCompilation(source, parseOptions);
+        var generator = new SerialPortReactiveStreamGenerator();
+        var driver = CSharpGeneratorDriver.Create([generator.AsSourceGenerator()], parseOptions: parseOptions);
+
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        var errors = outputCompilation.GetDiagnostics()
+            .Concat(diagnostics)
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        var generatedTree = outputCompilation.SyntaxTrees.Single(tree =>
+            tree.FilePath.EndsWith("GeneratedTests_DeviceState.SerialPortReactiveStreams.g.cs", StringComparison.Ordinal));
+        var generatedSource = generatedTree.ToString();
+
+        await Assert.That(errors).IsEmpty();
+        await Assert.That(generatedSource).Contains("public double Temperature");
+        await Assert.That(generatedSource).Contains("TemperatureObservable");
+        await Assert.That(generatedSource).Contains("TemperatureObservableAsync");
+        await Assert.That(generatedSource).Contains("public bool IsConnected");
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, CSharpParseOptions parseOptions)
+    {
+        var references = new List<MetadataReference>();
+        var trustedPlatformAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
+            .Split(Path.PathSeparator) ?? [];
+
+        references.AddRange(trustedPlatformAssemblies.Select(path => MetadataReference.CreateFromFile(path)));
+        references.Add(MetadataReference.CreateFromFile(typeof(SerialPortRx).Assembly.Location));
+        references.Add(MetadataReference.CreateFromFile(typeof(SerialPortReactiveValueConverter).Assembly.Location));
+        references.Add(MetadataReference.CreateFromFile(typeof(System.Reactive.Linq.Observable).Assembly.Location));
+        references.Add(MetadataReference.CreateFromFile(typeof(ReactiveUI.Extensions.Async.IObservableAsync<>).Assembly.Location));
+
+        return CSharpCompilation.Create(
+            "SerialPortRx.GeneratedTests",
+            [CSharpSyntaxTree.ParseText(source, parseOptions)],
+            references.DistinctBy(reference => reference.Display),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+    }
+}

--- a/src/SerialPortRx.Test/SerialPortRx.Test.csproj
+++ b/src/SerialPortRx.Test/SerialPortRx.Test.csproj
@@ -1,23 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>CP.IO.Ports.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);TUnit0015;TUnit0018</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="TUnit" Version="1.43.41" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SerialPortRx\SerialPortRx.csproj" />
+    <ProjectReference Include="..\SerialPortRx.SourceGenerators\SerialPortRx.SourceGenerators.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/SerialPortRx.Test/SerialPortRxTests.cs
+++ b/src/SerialPortRx.Test/SerialPortRxTests.cs
@@ -3,13 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Ports;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NUnit.Framework;
+using TUnit.Assertions;
+using TUnit.Core;
 
 namespace CP.IO.Ports.Tests;
 
@@ -18,10 +20,9 @@ namespace CP.IO.Ports.Tests;
 /// These tests require virtual COM port pairs (COM1-COM2) to be set up.
 /// Use a tool like com0com or Virtual Serial Port Driver to create virtual port pairs.
 /// </summary>
-[TestFixture]
 [Category("Integration")]
-[NonParallelizable]
-public class SerialPortRxTests
+[NotInParallel]
+public sealed class SerialPortRxTests : IDisposable
 {
     private const string Port1Name = "COM1";
     private const string Port2Name = "COM2";
@@ -30,39 +31,63 @@ public class SerialPortRxTests
     private SerialPortRx? _port1;
     private SerialPortRx? _port2;
     private CompositeDisposable? _disposables;
+    private bool _disposed;
 
     /// <summary>
     /// Check if test ports are available before running tests.
     /// </summary>
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
+    [Before(Class)]
+    public static void BeforeClass()
     {
         var availablePorts = SerialPort.GetPortNames();
         if (!Array.Exists(availablePorts, p => p.Equals(Port1Name, StringComparison.OrdinalIgnoreCase)) ||
             !Array.Exists(availablePorts, p => p.Equals(Port2Name, StringComparison.OrdinalIgnoreCase)))
         {
-            Assert.Ignore($"Test requires virtual COM port pair ({Port1Name} and {Port2Name}). " +
-                         "Use com0com or Virtual Serial Port Driver to create virtual ports.");
+            Skip.Test($"Test requires virtual COM port pair ({Port1Name} and {Port2Name}). " +
+                      "Use com0com or Virtual Serial Port Driver to create virtual ports.");
         }
     }
 
     /// <summary>
     /// Initializes resources required for each test.
     /// </summary>
-    [SetUp]
-    public void SetUp() => _disposables = new CompositeDisposable();
+    [Before(Test)]
+    public void BeforeTest() => _disposables = new CompositeDisposable();
 
     /// <summary>
     /// Performs cleanup operations after each test.
     /// </summary>
-    [TearDown]
-    public void TearDown()
+    /// <returns>A <see cref="Task"/> representing the asynchronous cleanup operation.</returns>
+    [After(Test)]
+    public async Task AfterTest()
     {
+        await Task.Delay(100);
+        DiscardBuffers(_port1);
+        DiscardBuffers(_port2);
+        _port1?.Close();
+        _port2?.Close();
+        Dispose();
+    }
+
+    /// <summary>
+    /// Releases resources used by the test instance.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        DiscardBuffers(_port1);
+        DiscardBuffers(_port2);
         _port1?.Close();
         _port2?.Close();
         _port1?.Dispose();
         _port2?.Dispose();
         _disposables?.Dispose();
+        _disposed = true;
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -70,7 +95,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Open_WithValidPort_SetsIsOpenToTrue()
     {
         // Arrange
@@ -80,7 +105,7 @@ public class SerialPortRxTests
         await _port1.Open();
 
         // Assert
-        Assert.That(_port1.IsOpen, Is.True);
+        await Assert.That(_port1.IsOpen).IsTrue();
     }
 
     /// <summary>
@@ -88,7 +113,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Close_AfterOpen_SetsIsOpenToFalse()
     {
         // Arrange
@@ -99,7 +124,7 @@ public class SerialPortRxTests
         _port1.Close();
 
         // Assert
-        Assert.That(_port1.IsOpen, Is.False);
+        await Assert.That(_port1.IsOpen).IsFalse();
     }
 
     /// <summary>
@@ -107,7 +132,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task IsOpenObservable_EmitsCorrectValues()
     {
         // Arrange
@@ -122,9 +147,9 @@ public class SerialPortRxTests
         await Task.Delay(100);
 
         // Assert
-        Assert.That(values, Has.Count.GreaterThanOrEqualTo(2));
-        Assert.That(values, Does.Contain(true));
-        Assert.That(values[^1], Is.False);
+        await Assert.That(values.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(values).Contains(true);
+        await Assert.That(values[^1]).IsFalse();
     }
 
     /// <summary>
@@ -132,7 +157,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task DataReceived_WhenDataWritten_EmitsReceivedCharacters()
     {
         // Arrange
@@ -160,8 +185,8 @@ public class SerialPortRxTests
         await Task.WhenAny(tcs.Task, Task.Delay(2000));
 
         // Assert
-        Assert.That(receivedChars.Count, Is.GreaterThanOrEqualTo(5));
-        Assert.That(string.Join(string.Empty, receivedChars), Does.StartWith("Hello"));
+        await Assert.That(receivedChars.Count).IsGreaterThanOrEqualTo(5);
+        await Assert.That(string.Join(string.Empty, receivedChars)).StartsWith("Hello");
     }
 
     /// <summary>
@@ -169,7 +194,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Lines_WhenLineWritten_EmitsCompleteLine()
     {
         // Arrange
@@ -194,7 +219,7 @@ public class SerialPortRxTests
         await Task.WhenAny(tcs.Task, Task.Delay(2000));
 
         // Assert
-        Assert.That(receivedLine, Is.EqualTo("Test Message"));
+        await Assert.That(receivedLine).IsEqualTo("Test Message");
     }
 
     /// <summary>
@@ -202,7 +227,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task DataReceivedBytes_WhenBytesWritten_EmitsReceivedBytes()
     {
         // Arrange
@@ -230,10 +255,10 @@ public class SerialPortRxTests
         await Task.WhenAny(tcs.Task, Task.Delay(2000));
 
         // Assert
-        Assert.That(receivedBytes.Count, Is.GreaterThanOrEqualTo(3));
-        Assert.That(receivedBytes[0], Is.EqualTo(0x01));
-        Assert.That(receivedBytes[1], Is.EqualTo(0x02));
-        Assert.That(receivedBytes[2], Is.EqualTo(0x03));
+        await Assert.That(receivedBytes.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(receivedBytes[0]).IsEqualTo((byte)0x01);
+        await Assert.That(receivedBytes[1]).IsEqualTo((byte)0x02);
+        await Assert.That(receivedBytes[2]).IsEqualTo((byte)0x03);
     }
 
     /// <summary>
@@ -241,7 +266,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task ReadLine_WhenDataAvailable_ReturnsLine()
     {
         // Arrange - disable auto receive to use sync reads
@@ -258,7 +283,7 @@ public class SerialPortRxTests
         var line = _port2.ReadLine();
 
         // Assert
-        Assert.That(line, Is.EqualTo("Sync Test"));
+        await Assert.That(line).IsEqualTo("Sync Test");
     }
 
     /// <summary>
@@ -266,7 +291,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task ReadExisting_WhenDataAvailable_ReturnsAllData()
     {
         // Arrange
@@ -283,7 +308,7 @@ public class SerialPortRxTests
         var data = _port2.ReadExisting();
 
         // Assert
-        Assert.That(data, Is.EqualTo("Test Data"));
+        await Assert.That(data).IsEqualTo("Test Data");
     }
 
     /// <summary>
@@ -291,7 +316,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Read_ByteArray_ReturnsCorrectBytes()
     {
         // Arrange
@@ -309,10 +334,10 @@ public class SerialPortRxTests
         var bytesRead = _port2.Read(buffer, 0, 3);
 
         // Assert
-        Assert.That(bytesRead, Is.EqualTo(3));
-        Assert.That(buffer[0], Is.EqualTo(65));
-        Assert.That(buffer[1], Is.EqualTo(66));
-        Assert.That(buffer[2], Is.EqualTo(67));
+        await Assert.That(bytesRead).IsEqualTo(3);
+        await Assert.That(buffer[0]).IsEqualTo((byte)65);
+        await Assert.That(buffer[1]).IsEqualTo((byte)66);
+        await Assert.That(buffer[2]).IsEqualTo((byte)67);
     }
 
     /// <summary>
@@ -320,7 +345,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task ReadLineAsync_WhenDataAvailable_ReturnsLine()
     {
         // Arrange
@@ -348,7 +373,7 @@ public class SerialPortRxTests
         var line = await readTask;
 
         // Assert
-        Assert.That(line, Is.EqualTo(testMessage));
+        await Assert.That(line).IsEqualTo(testMessage);
     }
 
     /// <summary>
@@ -356,7 +381,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task ReadLineAsync_WithCancellation_ThrowsOperationCanceled()
     {
         // Arrange
@@ -369,18 +394,8 @@ public class SerialPortRxTests
 
         using var cts = new CancellationTokenSource(500);
 
-        // Act & Assert - TaskCanceledException inherits from OperationCanceledException
-        Exception? caughtException = null;
-        try
-        {
-            await _port2.ReadLineAsync(cts.Token);
-        }
-        catch (Exception ex)
-        {
-            caughtException = ex;
-        }
-
-        Assert.That(caughtException, Is.InstanceOf<OperationCanceledException>());
+        // Act & Assert - TaskCanceledException inherits from OperationCanceledException.
+        await Assert.That(async () => await _port2.ReadLineAsync(cts.Token)).Throws<OperationCanceledException>();
     }
 
     /// <summary>
@@ -388,7 +403,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task ReadToAsync_WhenDelimiterFound_ReturnsDataUpToDelimiter()
     {
         // Arrange
@@ -405,7 +420,7 @@ public class SerialPortRxTests
         var result = await _port2.ReadToAsync(">");
 
         // Assert
-        Assert.That(result, Is.EqualTo("Hello"));
+        await Assert.That(result).IsEqualTo("Hello");
     }
 
     /// <summary>
@@ -413,7 +428,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Write_String_DataReceivedOnOtherPort()
     {
         // Arrange
@@ -429,7 +444,7 @@ public class SerialPortRxTests
 
         // Assert
         var received = _port2.ReadExisting();
-        Assert.That(received, Is.EqualTo("Test String"));
+        await Assert.That(received).IsEqualTo("Test String");
     }
 
     /// <summary>
@@ -437,7 +452,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task WriteLine_AddsNewLine()
     {
         // Arrange
@@ -453,7 +468,7 @@ public class SerialPortRxTests
 
         // Assert
         var received = _port2.ReadExisting();
-        Assert.That(received, Is.EqualTo("Test\n"));
+        await Assert.That(received).IsEqualTo("Test\n");
     }
 
     /// <summary>
@@ -461,7 +476,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Write_ByteArray_DataReceivedCorrectly()
     {
         // Arrange
@@ -488,11 +503,11 @@ public class SerialPortRxTests
         var bytesRead = _port2.Read(buffer, 0, 4);
 
         // Assert
-        Assert.That(bytesRead, Is.EqualTo(4));
-        Assert.That(buffer[0], Is.EqualTo(0xAA));
-        Assert.That(buffer[1], Is.EqualTo(0xBB));
-        Assert.That(buffer[2], Is.EqualTo(0xCC));
-        Assert.That(buffer[3], Is.EqualTo(0xDD));
+        await Assert.That(bytesRead).IsEqualTo(4);
+        await Assert.That(buffer[0]).IsEqualTo((byte)0xAA);
+        await Assert.That(buffer[1]).IsEqualTo((byte)0xBB);
+        await Assert.That(buffer[2]).IsEqualTo((byte)0xCC);
+        await Assert.That(buffer[3]).IsEqualTo((byte)0xDD);
     }
 
     /// <summary>
@@ -500,7 +515,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Write_CharArray_DataReceivedCorrectly()
     {
         // Arrange
@@ -518,31 +533,32 @@ public class SerialPortRxTests
 
         // Assert
         var received = _port2.ReadExisting();
-        Assert.That(received, Is.EqualTo("ABC"));
+        await Assert.That(received).IsEqualTo("ABC");
     }
 
     /// <summary>
     /// Verifies default property values.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    public void DefaultValues_AreSetCorrectly()
+    public async Task DefaultValues_AreSetCorrectly()
     {
         // Arrange & Act
         var port = new SerialPortRx();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.Multiple())
         {
-            Assert.That(port.BaudRate, Is.EqualTo(9600));
-            Assert.That(port.DataBits, Is.EqualTo(8));
-            Assert.That(port.Parity, Is.EqualTo(Parity.None));
-            Assert.That(port.StopBits, Is.EqualTo(StopBits.One));
-            Assert.That(port.Handshake, Is.EqualTo(Handshake.None));
-            Assert.That(port.NewLine, Is.EqualTo("\n"));
-            Assert.That(port.ReadTimeout, Is.EqualTo(-1));
-            Assert.That(port.WriteTimeout, Is.EqualTo(-1));
-            Assert.That(port.EnableAutoDataReceive, Is.True);
-        });
+            await Assert.That(port.BaudRate).IsEqualTo(9600);
+            await Assert.That(port.DataBits).IsEqualTo(8);
+            await Assert.That(port.Parity).IsEqualTo(Parity.None);
+            await Assert.That(port.StopBits).IsEqualTo(StopBits.One);
+            await Assert.That(port.Handshake).IsEqualTo(Handshake.None);
+            await Assert.That(port.NewLine).IsEqualTo("\n");
+            await Assert.That(port.ReadTimeout).IsEqualTo(-1);
+            await Assert.That(port.WriteTimeout).IsEqualTo(-1);
+            await Assert.That(port.EnableAutoDataReceive).IsTrue();
+        }
 
         port.Dispose();
     }
@@ -550,22 +566,23 @@ public class SerialPortRxTests
     /// <summary>
     /// Verifies constructor with all parameters.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    public void Constructor_WithAllParameters_SetsValuesCorrectly()
+    public async Task Constructor_WithAllParameters_SetsValuesCorrectly()
     {
         // Arrange & Act
         var port = new SerialPortRx("COM3", 115200, 7, Parity.Even, StopBits.Two, Handshake.RequestToSend);
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.Multiple())
         {
-            Assert.That(port.PortName, Is.EqualTo("COM3"));
-            Assert.That(port.BaudRate, Is.EqualTo(115200));
-            Assert.That(port.DataBits, Is.EqualTo(7));
-            Assert.That(port.Parity, Is.EqualTo(Parity.Even));
-            Assert.That(port.StopBits, Is.EqualTo(StopBits.Two));
-            Assert.That(port.Handshake, Is.EqualTo(Handshake.RequestToSend));
-        });
+            await Assert.That(port.PortName).IsEqualTo("COM3");
+            await Assert.That(port.BaudRate).IsEqualTo(115200);
+            await Assert.That(port.DataBits).IsEqualTo(7);
+            await Assert.That(port.Parity).IsEqualTo(Parity.Even);
+            await Assert.That(port.StopBits).IsEqualTo(StopBits.Two);
+            await Assert.That(port.Handshake).IsEqualTo(Handshake.RequestToSend);
+        }
 
         port.Dispose();
     }
@@ -575,51 +592,43 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Open_WithNonExistentPort_ThrowsException()
     {
         // Arrange
         _port1 = new SerialPortRx("COMNONEXISTENT", DefaultBaudRate);
 
-        // Act & Assert - Open throws for non-existent port
-        Exception? caughtException = null;
-        try
-        {
-            await _port1.Open();
-        }
-        catch (Exception ex)
-        {
-            caughtException = ex;
-        }
-
-        Assert.That(caughtException, Is.Not.Null);
-        Assert.That(_port1.IsOpen, Is.False);
+        // Act & Assert - Open throws for non-existent port.
+        await Assert.That(async () => await _port1.Open()).Throws<Exception>();
+        await Assert.That(_port1.IsOpen).IsFalse();
     }
 
     /// <summary>
     /// Verifies that ReadLine throws when port is not open.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    public void ReadLine_WhenPortNotOpen_ThrowsInvalidOperationException()
+    public async Task ReadLine_WhenPortNotOpen_ThrowsInvalidOperationException()
     {
         // Arrange
         _port1 = new SerialPortRx(Port1Name, DefaultBaudRate);
 
         // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => _port1.ReadLine());
+        await Assert.That(() => _port1.ReadLine()).Throws<InvalidOperationException>();
     }
 
     /// <summary>
     /// Verifies that ReadExisting throws when port is not open.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    public void ReadExisting_WhenPortNotOpen_ThrowsInvalidOperationException()
+    public async Task ReadExisting_WhenPortNotOpen_ThrowsInvalidOperationException()
     {
         // Arrange
         _port1 = new SerialPortRx(Port1Name, DefaultBaudRate);
 
         // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => _port1.ReadExisting());
+        await Assert.That(() => _port1.ReadExisting()).Throws<InvalidOperationException>();
     }
 
     /// <summary>
@@ -627,7 +636,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task PortNames_ReturnsAvailablePorts()
     {
         // Arrange
@@ -644,8 +653,8 @@ public class SerialPortRxTests
         await Task.WhenAny(tcs.Task, Task.Delay(2000));
 
         // Assert
-        Assert.That(receivedPorts, Has.Count.GreaterThanOrEqualTo(1));
-        Assert.That(receivedPorts[0], Does.Contain(Port1Name).Or.Contain(Port2Name));
+        await Assert.That(receivedPorts.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(receivedPorts[0]).Contains(Port1Name).Or.Contains(Port2Name);
     }
 
     /// <summary>
@@ -653,7 +662,7 @@ public class SerialPortRxTests
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    [CancelAfter(5000)]
+    [Timeout(5000)]
     public async Task Dispose_ClosesPortAndSetsIsDisposed()
     {
         // Arrange
@@ -664,25 +673,46 @@ public class SerialPortRxTests
         _port1.Dispose();
 
         // Assert
-        Assert.That(_port1.IsDisposed, Is.True);
-        Assert.That(_port1.IsOpen, Is.False);
+        await Assert.That(_port1.IsDisposed).IsTrue();
+        await Assert.That(_port1.IsOpen).IsFalse();
     }
 
     /// <summary>
     /// Verifies that Dispose can be called multiple times.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     [Test]
-    public void Dispose_CanBeCalledMultipleTimes()
+    public async Task Dispose_CanBeCalledMultipleTimes()
     {
         // Arrange
         _port1 = new SerialPortRx(Port1Name, DefaultBaudRate);
 
         // Act & Assert - should not throw
-        Assert.DoesNotThrow(() =>
+        await Assert.That(() =>
         {
             _port1.Dispose();
             _port1.Dispose();
             _port1.Dispose();
-        });
+        }).ThrowsNothing();
+    }
+
+    private static void DiscardBuffers(SerialPortRx? port)
+    {
+        if (port?.IsOpen != true)
+        {
+            return;
+        }
+
+        try
+        {
+            port.DiscardInBuffer();
+            port.DiscardOutBuffer();
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (IOException)
+        {
+        }
     }
 }

--- a/src/SerialPortRx.sln
+++ b/src/SerialPortRx.sln
@@ -22,20 +22,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ConfigFiles", "ConfigFiles"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SerialPortRx.Test", "SerialPortRx.Test\SerialPortRx.Test.csproj", "{6365DAE3-9EB7-4054-94E9-A3100C6637ED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerialPortRx.SourceGenerators", "SerialPortRx.SourceGenerators\SerialPortRx.SourceGenerators.csproj", "{2F573F59-3B55-4483-8A0D-3A36F8256660}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Debug|x64.Build.0 = Debug|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Debug|x86.Build.0 = Debug|Any CPU
 		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Release|x64.ActiveCfg = Release|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Release|x64.Build.0 = Release|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Release|x86.ActiveCfg = Release|Any CPU
+		{CDA3585B-D3D6-4BE4-9A6B-582AB5DE0B8F}.Release|x86.Build.0 = Release|Any CPU
 		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Debug|x86.Build.0 = Debug|Any CPU
 		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Release|x64.Build.0 = Release|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{6365DAE3-9EB7-4054-94E9-A3100C6637ED}.Release|x86.Build.0 = Release|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Release|x64.Build.0 = Release|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F573F59-3B55-4483-8A0D-3A36F8256660}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SerialPortRx/SerialPortRx.cs
+++ b/src/SerialPortRx/SerialPortRx.cs
@@ -16,6 +16,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ReactiveUI.Extensions.Async;
 
 namespace CP.IO.Ports;
 
@@ -51,8 +52,15 @@ public class SerialPortRx : ISerialPortRx
     private IObservable<Exception>? _cachedErrorReceived;
     private IObservable<bool>? _cachedIsOpenObservable;
     private IObservable<string>? _lines;
+    private IObservableAsync<char>? _cachedDataReceivedAsync;
+    private IObservableAsync<byte>? _cachedDataReceivedBytesAsync;
+    private IObservableAsync<int>? _cachedBytesReceivedAsync;
+    private IObservableAsync<Exception>? _cachedErrorReceivedAsync;
+    private IObservableAsync<bool>? _cachedIsOpenObservableAsync;
+    private IObservableAsync<string>? _linesAsync;
 #if HasWindows
     private IObservable<SerialPinChangedEventArgs>? _cachedPinChanged;
+    private IObservableAsync<SerialPinChangedEventArgs>? _cachedPinChangedAsync;
 #endif
 
     private SerialPort? _serialPort;
@@ -186,16 +194,34 @@ public class SerialPortRx : ISerialPortRx
     public IObservable<char> DataReceived => GetOrCreateCachedObservable(ref _cachedDataReceived, _dataReceived);
 
     /// <summary>
+    /// Gets the data received as characters via an async observable.
+    /// </summary>
+    /// <value>The data received.</value>
+    public IObservableAsync<char> DataReceivedAsync => GetOrCreateCachedAsyncObservable(ref _cachedDataReceivedAsync, DataReceived);
+
+    /// <summary>
     /// Gets the raw bytes received from the serial port.
     /// </summary>
     /// <value>The raw bytes received.</value>
     public IObservable<byte> DataReceivedBytes => GetOrCreateCachedObservable(ref _cachedDataReceivedBytes, _dataReceivedBytes);
 
     /// <summary>
+    /// Gets the raw bytes received from the serial port via an async observable.
+    /// </summary>
+    /// <value>The raw bytes received.</value>
+    public IObservableAsync<byte> DataReceivedBytesAsync => GetOrCreateCachedAsyncObservable(ref _cachedDataReceivedBytesAsync, DataReceivedBytes);
+
+    /// <summary>
     /// Gets the data received when executing ReadAsync.
     /// </summary>
     /// <value>The data received.</value>
     public IObservable<int> BytesReceived => GetOrCreateCachedObservable(ref _cachedBytesReceived, _bytesReceived);
+
+    /// <summary>
+    /// Gets the data received when executing ReadAsync via an async observable.
+    /// </summary>
+    /// <value>The data received.</value>
+    public IObservableAsync<int> BytesReceivedAsync => GetOrCreateCachedAsyncObservable(ref _cachedBytesReceivedAsync, BytesReceived);
 
     /// <summary>
     /// Gets or sets the encoding.
@@ -213,6 +239,12 @@ public class SerialPortRx : ISerialPortRx
     public IObservable<Exception> ErrorReceived => GetOrCreateCachedObservable(
         ref _cachedErrorReceived,
         () => _errors.Distinct(ex => ex.Message).Retry().Publish().RefCount());
+
+    /// <summary>
+    /// Gets the error received via an async observable.
+    /// </summary>
+    /// <value>The error received.</value>
+    public IObservableAsync<Exception> ErrorReceivedAsync => GetOrCreateCachedAsyncObservable(ref _cachedErrorReceivedAsync, ErrorReceived);
 
     /// <summary>
     /// Gets or sets the handshake.
@@ -246,6 +278,12 @@ public class SerialPortRx : ISerialPortRx
     public IObservable<bool> IsOpenObservable => GetOrCreateCachedObservable(
         ref _cachedIsOpenObservable,
         () => _isOpenValue.DistinctUntilChanged());
+
+    /// <summary>
+    /// Gets the is open async observable.
+    /// </summary>
+    /// <value>The is open async observable.</value>
+    public IObservableAsync<bool> IsOpenObservableAsync => GetOrCreateCachedAsyncObservable(ref _cachedIsOpenObservableAsync, IsOpenObservable);
 
     /// <summary>
     /// Gets or sets the parity.
@@ -499,12 +537,25 @@ public class SerialPortRx : ISerialPortRx
     /// The pin changed.
     /// </value>
     public IObservable<SerialPinChangedEventArgs> PinChanged => GetOrCreateCachedObservable(ref _cachedPinChanged, _pinChanged);
+
+    /// <summary>
+    /// Gets the pin changed async observable.
+    /// </summary>
+    /// <value>
+    /// The pin changed async observable.
+    /// </value>
+    public IObservableAsync<SerialPinChangedEventArgs> PinChangedAsync => GetOrCreateCachedAsyncObservable(ref _cachedPinChangedAsync, PinChanged);
 #endif
 
     /// <summary>
     /// Gets a lazily-created observable sequence of complete lines split by the NewLine sequence.
     /// </summary>
     public IObservable<string> Lines => _lines ??= CreateLinesObservable();
+
+    /// <summary>
+    /// Gets a lazily-created async observable sequence of complete lines split by the NewLine sequence.
+    /// </summary>
+    public IObservableAsync<string> LinesAsync => _linesAsync ??= Lines.ToObservableAsync();
 
     private IObservable<Unit> Connect => Observable.Create<Unit>(obs =>
     {
@@ -1567,6 +1618,32 @@ public class SerialPortRx : ISerialPortRx
             }
 
             var observable = factory();
+            Volatile.Write(ref cached, observable);
+            return observable;
+        }
+    }
+
+    /// <summary>
+    /// Creates a cached async observable that is thread-safe.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private IObservableAsync<T> GetOrCreateCachedAsyncObservable<T>(ref IObservableAsync<T>? cached, IObservable<T> source)
+    {
+        var current = Volatile.Read(ref cached);
+        if (current != null)
+        {
+            return current;
+        }
+
+        lock (_observableCacheLock)
+        {
+            current = Volatile.Read(ref cached);
+            if (current != null)
+            {
+                return current;
+            }
+
+            var observable = source.ToObservableAsync();
             Volatile.Write(ref cached, observable);
             return observable;
         }

--- a/src/SerialPortRx/SerialPortRx.csproj
+++ b/src/SerialPortRx/SerialPortRx.csproj
@@ -8,10 +8,20 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.Extensions" Version="2.2.1" />
+    <PackageReference Include="ReactiveUI.Extensions" Version="2.3.1" />
     <PackageReference Include="System.IO.Ports" Version="10.0.5" />
     <!-- Explicitly reference the core Rx package for reliability across TFMs -->
     <PackageReference Include="System.Reactive" Version="6.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SerialPortRx.SourceGenerators\SerialPortRx.SourceGenerators.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+    <None Include="..\SerialPortRx.SourceGenerators\bin\$(Configuration)\netstandard2.0\SerialPortRx.SourceGenerators.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/"
+          Visible="false" />
   </ItemGroup>
   
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/src/SerialPortRx/SerialPortRxMixins.cs
+++ b/src/SerialPortRx/SerialPortRxMixins.cs
@@ -9,6 +9,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using ReactiveUI.Extensions;
+using ReactiveUI.Extensions.Async;
 
 namespace CP.IO.Ports;
 
@@ -25,6 +26,13 @@ public static class SerialPortRxMixins
     public static IObservable<char> AsObservable(this byte value) => Observable.Return(Convert.ToChar(value));
 
     /// <summary>
+    /// Transforms a byte into a single value async observable.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns>An async observable char.</returns>
+    public static IObservableAsync<char> AsObservableAsync(this byte value) => ObservableAsync.Return(Convert.ToChar(value));
+
+    /// <summary>
     /// transforms a int into a single value Observable.
     /// </summary>
     /// <param name="value">The value.</param>
@@ -32,11 +40,141 @@ public static class SerialPortRxMixins
     public static IObservable<char> AsObservable(this int value) => Observable.Return(Convert.ToChar(value));
 
     /// <summary>
+    /// Transforms an int into a single value async observable.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns>An async observable char.</returns>
+    public static IObservableAsync<char> AsObservableAsync(this int value) => ObservableAsync.Return(Convert.ToChar(value));
+
+    /// <summary>
     /// transforms a short into a single value Observable.
     /// </summary>
     /// <param name="value">The value.</param>
     /// <returns>An Observable char.</returns>
     public static IObservable<char> AsObservable(this short value) => Observable.Return(Convert.ToChar(value));
+
+    /// <summary>
+    /// Transforms a short into a single value async observable.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns>An async observable char.</returns>
+    public static IObservableAsync<char> AsObservableAsync(this short value) => ObservableAsync.Return(Convert.ToChar(value));
+
+    /// <summary>
+    /// Gets the data received after opening a receive port as an async observable.
+    /// </summary>
+    /// <param name="this">The port.</param>
+    /// <returns>An async observable of received byte values.</returns>
+    public static IObservableAsync<int> BytesReceivedAsync(this IPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.BytesReceived.ToObservableAsync();
+    }
+
+    /// <summary>
+    /// Gets serial characters as an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <returns>An async observable of received characters.</returns>
+    public static IObservableAsync<char> DataReceivedAsync(this ISerialPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.DataReceived.ToObservableAsync();
+    }
+
+    /// <summary>
+    /// Gets serial bytes as an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <returns>An async observable of received bytes.</returns>
+    public static IObservableAsync<byte> DataReceivedBytesAsync(this ISerialPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.DataReceivedBytes.ToObservableAsync();
+    }
+
+    /// <summary>
+    /// Gets serial lines as an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <returns>An async observable of received lines.</returns>
+    public static IObservableAsync<string> LinesAsync(this ISerialPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.Lines.ToObservableAsync();
+    }
+
+    /// <summary>
+    /// Gets serial errors as an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <returns>An async observable of errors.</returns>
+    public static IObservableAsync<Exception> ErrorReceivedAsync(this ISerialPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.ErrorReceived.ToObservableAsync();
+    }
+
+    /// <summary>
+    /// Gets serial open-state changes as an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <returns>An async observable of open-state changes.</returns>
+    public static IObservableAsync<bool> IsOpenObservableAsync(this ISerialPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.IsOpenObservable.ToObservableAsync();
+    }
+
+#if HasWindows
+    /// <summary>
+    /// Gets serial pin changes as an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <returns>An async observable of pin change events.</returns>
+    public static IObservableAsync<SerialPinChangedEventArgs> PinChangedAsync(this ISerialPortRx @this)
+    {
+        if (@this == null)
+        {
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        return @this.PinChanged.ToObservableAsync();
+    }
+#endif
+
+    /// <summary>
+    /// Emits the list of available port names whenever it changes as an async observable.
+    /// </summary>
+    /// <param name="pollInterval">The poll interval.</param>
+    /// <param name="pollLimit">The poll limit.</param>
+    /// <returns>An async observable of port name arrays.</returns>
+    public static IObservableAsync<string[]> PortNamesAsync(int pollInterval = 500, int pollLimit = 0) =>
+        SerialPortRx.PortNames(pollInterval, pollLimit).ToObservableAsync();
 
     /// <summary>
     /// Buffers the Char values until the start and end chars have been found within the timeout period.
@@ -95,6 +233,20 @@ public static class SerialPortRxMixins
 
         return dis;
     });
+
+    /// <summary>
+    /// Buffers async Char values until the start and end chars have been found within the timeout period.
+    /// </summary>
+    /// <param name="this">The this.</param>
+    /// <param name="startsWith">The starts with.</param>
+    /// <param name="endsWith">The ends with.</param>
+    /// <param name="timeOut">The time out.</param>
+    /// <param name="scheduler">The scheduler.</param>
+    /// <returns>
+    /// An async observable string made up from the char values between the start and end chars.
+    /// </returns>
+    public static IObservableAsync<string> BufferUntil(this IObservableAsync<char> @this, IObservableAsync<char> startsWith, IObservableAsync<char> endsWith, int timeOut, IScheduler? scheduler = null) =>
+        @this.ToObservable().BufferUntil(startsWith.ToObservable(), endsWith.ToObservable(), timeOut, scheduler).ToObservableAsync();
 
     /// <summary>
     /// Buffers the Char values until the start and end chars have been found within the timeout
@@ -161,6 +313,30 @@ public static class SerialPortRxMixins
         });
 
     /// <summary>
+    /// Buffers async Char values until the start and end chars have been found within the timeout
+    /// period otherwise returns the default value.
+    /// </summary>
+    /// <param name="this">The this.</param>
+    /// <param name="startsWith">The starts with.</param>
+    /// <param name="endsWith">The ends with.</param>
+    /// <param name="defaultValue">The default value.</param>
+    /// <param name="timeOut">The time out.</param>
+    /// <param name="scheduler">The scheduler.</param>
+    /// <returns>
+    /// An async observable string made up from the char values between the start and end chars.
+    /// </returns>
+    public static IObservableAsync<string> BufferUntil(
+        this IObservableAsync<char> @this,
+        IObservableAsync<char> startsWith,
+        IObservableAsync<char> endsWith,
+        IObservableAsync<string> defaultValue,
+        int timeOut,
+        IScheduler? scheduler = null) =>
+        @this.ToObservable()
+            .BufferUntil(startsWith.ToObservable(), endsWith.ToObservable(), defaultValue.ToObservable(), timeOut, scheduler)
+            .ToObservableAsync();
+
+    /// <summary>
     /// Monitors the received observer.
     /// </summary>
     /// <param name="this">The this.</param>
@@ -195,4 +371,13 @@ public static class SerialPortRxMixins
             var isOpen = Observable.Interval(timespan).CombineLatest(@this.IsOpenObservable, (_, b) => b).Where(x => x);
             return isOpen.Subscribe(obs);
         }));
+
+    /// <summary>
+    /// Executes while port is open at the given TimeSpan via an async observable.
+    /// </summary>
+    /// <param name="this">The serial port.</param>
+    /// <param name="timespan">The timespan at which to notify.</param>
+    /// <returns>Async observable value.</returns>
+    public static IObservableAsync<bool> WhileIsOpenAsync(this SerialPortRx @this, TimeSpan timespan) =>
+        @this.WhileIsOpen(timespan).ToObservableAsync();
 }

--- a/src/SerialPortRx/SourceGeneration/SerialPortReactiveValueConverter.cs
+++ b/src/SerialPortRx/SourceGeneration/SerialPortReactiveValueConverter.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace CP.IO.Ports.SourceGeneration;
+
+/// <summary>
+/// Converts generated serial stream values into strongly typed reactive properties.
+/// </summary>
+public static class SerialPortReactiveValueConverter
+{
+    /// <summary>
+    /// Tries to match and convert a serial stream value.
+    /// </summary>
+    /// <typeparam name="T">The target type.</typeparam>
+    /// <param name="value">The raw stream value.</param>
+    /// <param name="pattern">The optional regular expression pattern.</param>
+    /// <param name="groupName">The optional named group to convert.</param>
+    /// <param name="groupNumber">The fallback group number to convert.</param>
+    /// <param name="ignoreCase">A value indicating whether the match ignores case.</param>
+    /// <param name="result">The converted value.</param>
+    /// <returns><c>true</c> when a value was matched and converted; otherwise, <c>false</c>.</returns>
+    public static bool TryConvertMatch<T>(
+        object? value,
+        string? pattern,
+        string? groupName,
+        int groupNumber,
+        bool ignoreCase,
+        out T result)
+    {
+        result = default!;
+
+        var text = Convert.ToString(value, CultureInfo.InvariantCulture);
+        if (text == null)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(pattern))
+        {
+            var options = RegexOptions.CultureInvariant;
+            if (ignoreCase)
+            {
+                options |= RegexOptions.IgnoreCase;
+            }
+
+            var match = Regex.Match(text, pattern!, options);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            text = GetMatchValue(match, groupName, groupNumber);
+        }
+
+        return TryConvert(text, out result);
+    }
+
+    private static string GetMatchValue(Match match, string? groupName, int groupNumber)
+    {
+        if (!string.IsNullOrWhiteSpace(groupName))
+        {
+            var namedGroup = match.Groups[groupName!];
+            if (namedGroup.Success)
+            {
+                return namedGroup.Value;
+            }
+        }
+
+        if (groupNumber >= 0 && groupNumber < match.Groups.Count)
+        {
+            var numberedGroup = match.Groups[groupNumber];
+            if (numberedGroup.Success)
+            {
+                return numberedGroup.Value;
+            }
+        }
+
+        return match.Value;
+    }
+
+    private static bool TryConvert<T>(string value, out T result)
+    {
+        result = default!;
+        var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+        try
+        {
+            object? converted;
+            if (targetType == typeof(string))
+            {
+                converted = value;
+            }
+            else if (targetType == typeof(char))
+            {
+                if (value.Length != 1)
+                {
+                    return false;
+                }
+
+                converted = value[0];
+            }
+            else if (targetType == typeof(bool))
+            {
+                converted = bool.TryParse(value, out var boolValue)
+                    ? boolValue
+                    : value switch
+                    {
+                        "1" => true,
+                        "0" => false,
+                        _ => throw new FormatException("Value is not a valid Boolean."),
+                    };
+            }
+            else if (targetType.IsEnum)
+            {
+                converted = Enum.Parse(targetType, value, ignoreCase: true);
+            }
+            else if (targetType == typeof(Guid))
+            {
+                converted = Guid.Parse(value);
+            }
+            else if (targetType == typeof(DateTime))
+            {
+                converted = DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            }
+            else if (targetType == typeof(DateTimeOffset))
+            {
+                converted = DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            }
+            else
+            {
+                var converter = TypeDescriptor.GetConverter(targetType);
+                converted = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+            }
+
+            result = (T)converted!;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/SerialPortRx/TcpClientRx.cs
+++ b/src/SerialPortRx/TcpClientRx.cs
@@ -12,6 +12,7 @@ using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using ReactiveUI.Extensions;
+using ReactiveUI.Extensions.Async;
 
 namespace CP.IO.Ports;
 
@@ -24,6 +25,9 @@ public class TcpClientRx : IPortRx
     private readonly Subject<int> _bytesReceived = new();
     private readonly Subject<int> _dataReceived = new();
     private readonly Subject<byte[]> _dataChunks = new();
+    private IObservableAsync<int>? _dataReceivedAsync;
+    private IObservableAsync<byte[]>? _dataReceivedBatchesAsync;
+    private IObservableAsync<int>? _bytesReceivedAsync;
     private CompositeDisposable _disposablePort = [];
     private bool _disposedValue;
 
@@ -115,15 +119,32 @@ public class TcpClientRx : IPortRx
     public IObservable<int> DataReceived => _dataReceived.Retry().Publish().RefCount();
 
     /// <summary>
+    /// Gets the data received after calling Open as an async observable.
+    /// </summary>
+    /// <value>The data received.</value>
+    public IObservableAsync<int> DataReceivedAsync => _dataReceivedAsync ??= DataReceived.ToObservableAsync();
+
+    /// <summary>
     /// Gets stream chunks (byte arrays) produced by the internal read loop.
     /// </summary>
     public IObservable<byte[]> DataReceivedBatches => _dataChunks.Retry().Publish().RefCount();
+
+    /// <summary>
+    /// Gets stream chunks produced by the internal read loop as an async observable.
+    /// </summary>
+    public IObservableAsync<byte[]> DataReceivedBatchesAsync => _dataReceivedBatchesAsync ??= DataReceivedBatches.ToObservableAsync();
 
     /// <summary>
     /// Gets the data received From ReadAsync.
     /// </summary>
     /// <value>The data received.</value>
     public IObservable<int> BytesReceived => _bytesReceived.Retry().Publish().RefCount();
+
+    /// <summary>
+    /// Gets the data received from ReadAsync as an async observable.
+    /// </summary>
+    /// <value>The data received.</value>
+    public IObservableAsync<int> BytesReceivedAsync => _bytesReceivedAsync ??= BytesReceived.ToObservableAsync();
 
     /// <summary>
     /// Connects the specified hostname.

--- a/src/SerialPortRx/UdpClientRx.cs
+++ b/src/SerialPortRx/UdpClientRx.cs
@@ -13,6 +13,7 @@ using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using ReactiveUI.Extensions;
+using ReactiveUI.Extensions.Async;
 
 namespace CP.IO.Ports;
 
@@ -27,6 +28,9 @@ public class UdpClientRx : IPortRx
     private readonly Subject<int> _bytesReceived = new();
     private readonly Subject<int> _dataReceived = new();
     private readonly Subject<byte[]> _dataChunks = new();
+    private IObservableAsync<int>? _dataReceivedAsync;
+    private IObservableAsync<byte[]>? _dataReceivedBatchesAsync;
+    private IObservableAsync<int>? _bytesReceivedAsync;
     private CompositeDisposable _disposablePort = [];
     private bool _disposedValue;
     private int _bufferOffset;
@@ -172,15 +176,32 @@ public class UdpClientRx : IPortRx
     public IObservable<int> DataReceived => _dataReceived.Retry().Publish().RefCount();
 
     /// <summary>
+    /// Gets the data received as an async observable.
+    /// </summary>
+    /// <value>The data received.</value>
+    public IObservableAsync<int> DataReceivedAsync => _dataReceivedAsync ??= DataReceived.ToObservableAsync();
+
+    /// <summary>
     /// Gets stream chunks (byte arrays) for each received UDP datagram.
     /// </summary>
     public IObservable<byte[]> DataReceivedBatches => _dataChunks.Retry().Publish().RefCount();
+
+    /// <summary>
+    /// Gets stream chunks for each received UDP datagram as an async observable.
+    /// </summary>
+    public IObservableAsync<byte[]> DataReceivedBatchesAsync => _dataReceivedBatchesAsync ??= DataReceivedBatches.ToObservableAsync();
 
     /// <summary>
     /// Gets the data received.
     /// </summary>
     /// <value>The data received.</value>
     public IObservable<int> BytesReceived => _bytesReceived.Retry().Publish().RefCount();
+
+    /// <summary>
+    /// Gets the data received from ReadAsync as an async observable.
+    /// </summary>
+    /// <value>The data received.</value>
+    public IObservableAsync<int> BytesReceivedAsync => _bytesReceivedAsync ??= BytesReceived.ToObservableAsync();
 
 #if HasWindows
     /// <summary>


### PR DESCRIPTION
Introduce a source generator for serial-port reactive streams and wire up testing/docs. 
Adds a new SerialPortRx.SourceGenerators project with SerialPortReactiveStreamAttribute and SerialPortReactiveStreamGenerator to generate strongly-typed properties, IObservable and IObservableAsync streams, and a ConnectReactiveSerialPort hookup. 
Adds generator unit tests (TUnit) and switches the test project from NUnit to TUnit, updating tests to the async/assert patterns and referencing the new generator project. 
Update README to document async observables, source-generator usage and test instructions; add global.json test runner config; add SerialPortReactiveValueConverter helper and update solution/project references and package metadata (Directory.Build.props).